### PR TITLE
refactor api.go in light of issue #4, add tests and benchmark

### DIFF
--- a/gospell.go
+++ b/gospell.go
@@ -81,7 +81,7 @@ func initialModel(credentialPath string, ctx context.Context) model {
 	ttsState.Ctx = ctx
 
 	// Get a random word and its definition.
-	word := api.GetAcceptableWord()
+	word := api.RandomWord()
 	return model{
 		textInput:       ti,
 		credentialPath:  credentialPath,
@@ -115,7 +115,7 @@ func (m *model) Init() tea.Cmd {
 // Command to generate a new word.
 func getNewWord(m *model) tea.Cmd {
 	return func() tea.Msg {
-		word := api.GetAcceptableWord()
+		word := api.RandomWord()
 		def := m.definitionState.GetDefinition(word)
 
 		// Play the word audio in a goroutine to avoid blocking.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,50 +1,22 @@
 package api
 
 import (
-	"bufio"
-	"embed"
-	"log"
+	_ "embed"
 	"math/rand"
-	"time"
+	"strings"
 )
 
-// GetAcceptableWord returns a random word from the wordlist.
-func GetAcceptableWord() string {
-	var timeBetweenWords = 100 * time.Millisecond
-	time.Sleep(timeBetweenWords) // Sleep to allow time for the user to see feedback
-	return getRandomLineFromWordlist()
+//go:embed wordlist.txt
+var wordlist string
+
+var words = splitWords(wordlist)
+
+func splitWords(wordlist string) []string {
+	return strings.Split(wordlist, "\n")
 }
 
-//go:embed wordlist.txt
-var fs embed.FS
-
-// From The Art of Computer Programming, Volume 2, Section 3.4.2, by Donald E. Knuth.
-// This is a reservoir sampling algorithm that picks a random line from a file.
-func getRandomLineFromWordlist() string {
-	file, err := fs.Open("wordlist.txt")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-
-	randsource := rand.NewSource(time.Now().UnixNano())
-	randgenerator := rand.New(randsource)
-
-	lineNum := 1
-	var pick string
-	for scanner.Scan() {
-		line := scanner.Text()
-		// Instead of 1 to N it's 0 to N-1
-		roll := randgenerator.Intn(lineNum)
-		if roll == 0 {
-			// We pick this line
-			pick = line
-		}
-
-		lineNum += 1
-	}
-
-	return pick
+// RandomWord returns a random word from the embedded word list
+func RandomWord() string {
+	i := rand.Intn(len(words))
+	return words[i]
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -17,16 +17,20 @@ func TestGetRandomLineFromWordlist(t *testing.T) {
 	}
 }
 
-func BenchmarkRandomWord(b *testing.B) {
-	var word string
-	for b.Loop() {
-		word = RandomWord()
-	}
-	b.Logf("Random word: %v", word)
-}
-
 func BenchmarkSplitWords(b *testing.B) {
 	for b.Loop() {
 		_ = splitWords(wordlist)
+	}
+}
+
+func BenchmarkRandomWord(b *testing.B) {
+	for b.Loop() {
+		_ = RandomWord()
+	}
+}
+
+func BenchmarkSafeRandomWord(b *testing.B) {
+	for b.Loop() {
+		_ = SafeRandomWord()
 	}
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,32 @@
+package api
+
+import "testing"
+
+func TestGetRandomLineFromWordlist(t *testing.T) {
+	word := RandomWord()
+	t.Logf("Random word: %v", word)
+
+	if len(word) == 0 {
+		t.Errorf("Expected a non-empty word, got empty string")
+	}
+	if len(word) > 20 {
+		t.Errorf("Expected a word of length <= 20, got %d", len(word))
+	}
+	if word == "a" || word == "I" {
+		t.Errorf("Expected a word other than 'a' or 'I', got %s", word)
+	}
+}
+
+func BenchmarkRandomWord(b *testing.B) {
+	var word string
+	for b.Loop() {
+		word = RandomWord()
+	}
+	b.Logf("Random word: %v", word)
+}
+
+func BenchmarkSplitWords(b *testing.B) {
+	for b.Loop() {
+		_ = splitWords(wordlist)
+	}
+}

--- a/internal/api/safeword.go
+++ b/internal/api/safeword.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	_ "embed"
+	"hash/maphash"
+	"math/rand"
+	"strings"
+)
+
+//go:embed wordlist.txt
+var fileString string
+var file []string = strings.Split(fileString, "\n")
+var rng = NewRand()
+
+// RandomWord returns a random word from the wordlist.
+func SafeRandomWord() string {
+    randomNumber := rng.Intn(len(file))
+    return file[randomNumber]
+}
+
+// Rand64 returns a pseudo-random uint64. It can be used concurrently and is lock-free.
+// Effectively, it calls runtime.fastrand.
+func Rand64() uint64 {
+    return new(maphash.Hash).Sum64()
+}
+
+// NewRand returns a properly seeded *rand.Rand. It has *slightly* higher overhead than
+// Rand64 (as it has to allocate), but the resulting PRNG can be re-used to offset that cost.
+func NewRand() *rand.Rand {
+    return rand.New(rand.NewSource(int64(Rand64())))
+}


### PR DESCRIPTION
This is an instructional PR for @jharlan-hash and not intended to be merged.

You mention in #4 that your your best time is 900ns. In here I have benchmark tests that show your version at 6.874 ns on my machine 

```
msw@omen ~/gospell (tests)> cd internal/api/
msw@omen ~/g/i/api (tests)> go test -bench . -benchmem
goos: linux
goarch: amd64
pkg: github.com/jharlan-hash/gospell/internal/api
cpu: AMD Ryzen 7 5800X 8-Core Processor             
BenchmarkSplitWords-16              1632            741550 ns/op         1458186 B/op          1 allocs/op
BenchmarkRandomWord-16          100000000               11.36 ns/op            0 B/op          0 allocs/op
BenchmarkSafeRandomWord-16      174500996                6.874 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/jharlan-hash/gospell/internal/api    3.555s
```

I don't know how you were timing, but go Benchmark tests appear to be the proper way to do them. Now, I'm curious as to why your SafeRandomWord is faster than mine ;)  Of course, quibbling over nanoseconds for this operation is not of practical importance, but I know I am learning things that will matter as I code bigger.

I am enjoying this review process, and it appears you are as well. Please let me know if you'd appreciate my continuing. Just because it is fun for me does not mean it need be for you.